### PR TITLE
Do not use instance profile credentials with s3 client

### DIFF
--- a/kela-service/src/main/java/fi/vm/sade/rajapinnat/kela/AbstractOPTIWriter.java
+++ b/kela-service/src/main/java/fi/vm/sade/rajapinnat/kela/AbstractOPTIWriter.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.s3.model.*;
 import fi.vm.sade.organisaatio.resource.dto.OrganisaatioRDTO;
 import fi.vm.sade.rajapinnat.kela.config.UrlConfiguration;
@@ -69,9 +68,7 @@ public abstract class AbstractOPTIWriter {
     private AmazonS3 getS3client(){
         if(s3client == null){
             try {
-                InstanceProfileCredentialsProvider ipcp = InstanceProfileCredentialsProvider.createAsyncRefreshingProvider(true);
                 s3client = AmazonS3ClientBuilder.standard()
-                        .withCredentials(ipcp)
                         .withRegion(Regions.fromName(s3region))
                         .build();
                 LOG.info("S3client initialized");


### PR DESCRIPTION
It uses default credentials provider if no credentials provider is specified; this is the desired behavior.

With default credentials, the S3 bucket is accessed using ECS Task Role instead of the EC2 Instance Role. The latter has been used in our AWS environments until now, but we want to minimize the instance role's permissions, and instead make all containerized services use their own task roles.